### PR TITLE
CI: Add 2.7 to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 rvm:
 - 2.2.4
 - 2.3.1
+- 2.7.0
 - jruby-9.0.5.0
 env:
   global:


### PR DESCRIPTION
## Why

Show failures for example of 2.7 issues of gem

## Changes

- Add 2.7.0 to travis build matrix